### PR TITLE
Upgrade profile README: fix dead streak-stats host + add projects CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ mindset:    "Build with intent. Refine with discipline. Ship in public."
   </tr>
 </table>
 
+<div align="center">
+  <a href="https://github.com/vishesh-py?tab=repositories">
+    <img src="https://img.shields.io/badge/Explore%20all%20projects-6366F1?style=for-the-badge&logo=github&logoColor=white" alt="explore all projects" />
+  </a>
+</div>
+
 <img width="100%" src="https://capsule-render.vercel.app/api?type=rect&color=0:6366F1,100:7C3AED&height=3" />
 
 <div align="center">
@@ -151,7 +157,7 @@ mindset:    "Build with intent. Refine with discipline. Ship in public."
 ### &#128202; GitHub Analytics
 
 <img height="170em" src="https://github-readme-stats.vercel.app/api?username=vishesh-py&show_icons=true&theme=react&include_all_commits=true&count_private=true&hide_border=true&bg_color=0D1117&title_color=6366F1&icon_color=7C3AED&text_color=C9D1D9" alt="github stats" />
-<img height="170em" src="https://github-readme-streak-stats.herokuapp.com/?user=vishesh-py&theme=react&hide_border=true&background=0D1117&ring=6366F1&fire=7C3AED&currStreakLabel=6366F1" alt="streak stats" />
+<img height="170em" src="https://streak-stats.demolab.com?user=vishesh-py&theme=react&hide_border=true&background=0D1117&ring=6366F1&fire=7C3AED&currStreakLabel=6366F1" alt="streak stats" />
 
 <br/>
 


### PR DESCRIPTION
## Summary

Focused, reliability-first upgrade to the profile `README.md`. Preserves the existing indigo/purple theme and layout while removing a broken image and adding a small call-to-action.

### Changes
1. **Fix dead streak-stats image** — swapped the deprecated `github-readme-streak-stats.herokuapp.com` host for the maintained `streak-stats.demolab.com` host. The Heroku host is no longer served, so the streak card was rendering broken for visitors.
2. **Add an "Explore all projects" CTA** — a centered button under *Featured Projects* linking to the repositories tab, so visitors can browse everything beyond the two highlighted projects.

### Verification
All image endpoints used in this change were checked over HTTP:
- `streak-stats.demolab.com` → `200`, `image/svg+xml` (valid SVG, 7 KB) ✅
- `img.shields.io` CTA badge → `200` ✅

### Notes / things I intentionally did NOT change (need your input)
- **GitHub Trophies** — I tried to add a trophy row, but the upstream host (`github-profile-trophy.vercel.app`) currently returns `DEPLOYMENT_DISABLED` / `402`, so it would render broken. Left out on purpose.
- **`github-readme-stats` cards** — the shared `github-readme-stats.vercel.app` host is currently rate-limited (`503`) from external checks. This is a long-standing issue with the popular shared instance and affects your existing *Stats* and *Top Languages* cards. Options if you want rock-solid reliability: self-host your own instance, or switch to `github-profile-summary-cards.vercel.app` (verified healthy). Happy to do either.
- **Telegram link** — the current link `https://t.me/vishesh-py` is invalid (Telegram usernames can't contain hyphens), so it's broken. Tell me which handle to use and I'll fix it.

Co-authored-by: Vishesh <visheshggits@gmail.com>